### PR TITLE
Dythya/minor fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,13 +28,13 @@ is now known as SimpyClassic.
 Installation
 ------------
 
-SimPy requires Python 2.6 or above (including Python 3).
+SimPy requires Python 2.7 or Python 3.
 
 You can install SimPy easily via `PIP <http://pypi.python.org/pypi/pip>`_::
 
     $ pip install -U SimPy
 
-You can also download and install SimPy manually::
+You can also download and install SimPy manually. It can be found at `https://github.com/SimPyClassic/SimPyClassic`::
 
     $ cd where/you/put/simpy/
     $ python setup.py install

--- a/docs/SManual/source/SManual.rst
+++ b/docs/SManual/source/SManual.rst
@@ -12,7 +12,7 @@ Introduction to SimPy
 :Authors: G A Vignaux and Klaus Muller
 :Date:  |today|
 :SimPy release: |release|
-:Python-Version: 2.6 and later
+:Python-Version: 2.7 and later
 
 .. THIS WAS PUT UNDER SUBVERSION 2008/08/07
 
@@ -1048,7 +1048,7 @@ the ``gasstation``.)
 .. some useful stuff used above
 
 
-.. _`simpydownload`: http://sourceforge.net/projects/simpy/
+.. _`simpydownload`: https://github.com/SimPyClassic/SimPyClassic
 .. _`Python web-site` : http://www.Python.org
 
 

--- a/docs/examples/source/ListOfModels.rst
+++ b/docs/examples/source/ListOfModels.rst
@@ -4,7 +4,7 @@
 
 :SimPy version: 2.3
 :Web-site: http://simpy.sourceforge.net/
-:Python-Version: 2.6 or later and 3.x except for the GUI ones
+:Python-Version: 2.7 or later and 3.x except for the GUI ones
 
 These models are examples of SimPy use written by several authors and usually
 developed for other purposes, such as teaching and consulting. They are in a

--- a/docs/source/Manuals/COMPATIBILITY.rst
+++ b/docs/source/Manuals/COMPATIBILITY.rst
@@ -4,10 +4,11 @@ COMPATIBILITY: SimPy
 SimPy has been used successfully with many packages and modules, such as
 Tk/Tkinter for GUIs and VPython and matplotlib for graphical output.
 
-The design of SimPy is such that no incompatibilities with Python 2.3 through
-2.6 modules or Python 2.3 through 2.6-accessible packages are expected.
+The design of SimPy is such that no incompatibilities with Python 2.7 through
+3.6 modules or Python 2.7 through 3.6-accessible packages are expected.
 
-SimPy |release| has been tested with Python 2.3, 2.4, 2.5, 2.6 and 2.7.
+SimPy |release| has been tested with Python 2.7, 3.4, 3.5, 3.6. On Linux and
+Windows 10.
 
 Should SimPy users discover any incompatibilities, the authors would be
 grateful for a report. Just send a message with the problem  and its context

--- a/docs/source/Manuals/GUIManual/SimGUImanual.rst
+++ b/docs/source/Manuals/GUIManual/SimGUImanual.rst
@@ -7,8 +7,9 @@
 :Authors: Klaus Muller <Muller@users.sourceforge.net>
 :SimPy release: |release|
 :Web-site: http://simpy.sourceforge.net/
-:Python-Version: 2.6 and later
+:Python-Version: 2.7 and later
 :Date: December 2011
+:Updated: January 2018
 
 
 .. contents:: Contents

--- a/docs/source/Manuals/Manual.rst
+++ b/docs/source/Manuals/Manual.rst
@@ -14,7 +14,8 @@ SimPy Manual
           - Bob Helmbold
 :SimPy release: |release|
 :SimPy Web-site: http://simpy.sourceforge.net/
-:Python-Version: 2.6 and later
+:SimPy Source: https://github.com/SimPyClassic/SimPyClassic
+:Python-Version: 2.7 and later
 :Date: |today|
 
 
@@ -3207,7 +3208,7 @@ Glossary
 
 
 .. .. |simpylogo| image:: images/sm_SimPy_Logo.png
-.. _`simpydownload`: http://sourceforge.net/projects/simpy/
+.. _`simpydownload`: https://github.com/SimPyClassic/SimPyClassic
 
 .. _`Python random module`: http://www.python.org/doc/current/lib/module-random.html
 

--- a/docs/source/Manuals/PlotManual/ManualPlotting.rst
+++ b/docs/source/Manuals/PlotManual/ManualPlotting.rst
@@ -8,8 +8,9 @@
 :Authors: Klaus Muller <Muller@users.sourceforge.net>
 :SimPy release: |release|
 :Web-site: http://simpy.sourceforge.net/
-:Python-Version: 2.6 and later
+:Python-Version: 2.7 and later
 :Date: December 2011
+:Updated: January 2018
 
 
 .. contents:: Contents

--- a/docs/source/Manuals/RESOURCES.rst
+++ b/docs/source/Manuals/RESOURCES.rst
@@ -2,7 +2,7 @@
 SimPy Resources
 ===============
 
-SimPy can be downloaded from the "SimPy web-site": http://simpy.sourceforge.net.
+SimPy can be downloaded from the "SimPy web-site": https://github.com/SimPyClassic/SimPyClassic
 
 Simulation model developers are encouraged to share their SimPy modeling
 techniques with the SimPy community. Please "post a message to the simpy-Users

--- a/docs/source/Manuals/SimPyOO_API.rst
+++ b/docs/source/Manuals/SimPyOO_API.rst
@@ -4,7 +4,7 @@ SimPy's Object Oriented API
 
 :Authors: - Klaus Muller <Muller@users.sourceforge.net>
 :SimPy release: |release|
-:Python version: 2.6 and later
+:Python version: 2.7 and later
 :Date: |today|
 
 .. contents:: Contents

--- a/docs/source/Manuals/SimRTManual.rst
+++ b/docs/source/Manuals/SimRTManual.rst
@@ -11,8 +11,9 @@
           - Tony Vignaux <Vignaux@users.sourceforge.net>
 :SimPy release: |release|
 :Web-site: http://simpy.sourceforge.net/
-:Python-Version: 2.6+
+:Python-Version: 2.7+
 :Date: December 2011
+:Updated: January 2018
 
 .. contents:: Contents
    :depth: 3
@@ -67,7 +68,7 @@ Here is an example:
 
 The program changes the time ratio twice, at simulation times 5 and 10.
 
-When run on a Windows Vista computer under Python 2.6, this results in this output:
+When run on a Windows Vista computer under Python 2.7, this results in this output:
 
 .. literalinclude:: SimulationRTprograms/variableTimeRatio.out
 

--- a/docs/source/Manuals/SimStepManual.rst
+++ b/docs/source/Manuals/SimStepManual.rst
@@ -9,8 +9,9 @@ Simulation with Event Stepping
           - Tony Vignaux <Vignaux@users.sourceforge.net>
 :SimPy release: |release|
 :Web-site: http://simpy.sourceforge.net/
-:Python-Version: 2.6+
+:Python-Version: 2.7+
 :Date: December 2011
+:Updated: January 2018
 
 .. contents:: Contents
    :depth: 2

--- a/docs/source/Manuals/Tracing.rst
+++ b/docs/source/Manuals/Tracing.rst
@@ -8,8 +8,9 @@ Simulation with Tracing
 :Authors: - Klaus Muller <Muller@users.sourceforge.net>
 :SimPy release: |release|
 :Web-site: http://simpy.sourceforge.net/
-:Python-Version: 2.6 and later
+:Python-Version: 2.7 and later
 :Date: December 2011
+:Updated: January 2018
 
 .. contents:: Contents
    :depth: 2

--- a/docs/source/Tutorials/TheBank.rst
+++ b/docs/source/Tutorials/TheBank.rst
@@ -29,7 +29,7 @@ approach which is used in most of the models described here.
 
 .. _`SimPy`: http://simpy.sourceforge.net/
 
-SimPy can be obtained from: http://sourceforge.net/projects/simpy.
+SimPy can be obtained from: https://github.com/SimPyClassic/SimPyClassic.
 The examples run with SimPy version 1.5 and later.  This tutorial is
 best read with the SimPy Manual or Cheatsheet at your side for
 reference.
@@ -38,7 +38,7 @@ Before attempting to use SimPy you should be familiar with the Python_
 language. In particular you should be able to use *classes*. Python is
 free and available for most machine types. You can find out more about
 it at the `Python web site`_.  SimPy is compatible with Python version
-2.6 and later including Python 3.
+2.7 and Python 3.x.
 
 .. _Python: http://www.Python.org
 .. _`Python web site`: http://www.Python.org

--- a/docs/source/Tutorials/TheBank2.rst
+++ b/docs/source/Tutorials/TheBank2.rst
@@ -18,8 +18,9 @@ The Bank Tutorial part 2: More  examples of SimPy Simulation
 
 :Author: G A Vignaux  
 :Date:  2012 February
+:Updated: January 2018
 :SimPy release: |release|
-:Python-Version: 2.6 and later
+:Python-Version: 2.7 and later
 
 
 .. highlight:: python
@@ -84,9 +85,10 @@ directory ``bankprograms``. Some have trace statements for
 demonstration purposes, others produce graphical output to the
 screen. Let me encourage you to run them and modify them for yourself
 
-SimPy itself can be obtained from: http://simpy.sourceforge.net/.  It
-is compatible with Python version 2.6 onwards.  The examples in this
-documentation run with SimPy version 1.5 and later.
+SimPy itself can be obtained from:
+https://github.com/SimPyClassic/SimPyClassic.  It is compatible with
+Python version 2.7 onwards.  The examples in this documentation run
+with SimPy version 1.5 and later.
 
 This tutorial should be read with the SimPy Manual or Cheatsheet at
 your side for reference. 
@@ -382,7 +384,7 @@ References
 
 - Python website: http://www.Python.org
 
-- SimPy homepage: http://simpy.sourceforge.net/
+- SimPy homepage: https://github.com/SimPyClassic/SimPyClassic
 
 - The Bank:
 

--- a/docs/source/Tutorials/TheBank2OO.rst
+++ b/docs/source/Tutorials/TheBank2OO.rst
@@ -10,7 +10,7 @@ The Bank Tutorial (OO API) Part 2: More  examples of SimPy Simulation
 :Authors: G A Vignaux, K G Muller
 :Date:  2010 April
 :SimPy release: |release|
-:Python-Version: 2.6 and later
+:Python-Version: 2.7 and later
 
 .. ---------------------------------------------------
 ..  TO DO
@@ -102,9 +102,10 @@ directory ``bankprograms``. Some have trace statements for
 demonstration purposes, others produce graphical output to the
 screen. Let me encourage you to run them and modify them for yourself.
 
-SimPy itself can be obtained from: http://simpy.sourceforge.net/.  It
-is compatible with Python version 2.3 onwards.  The examples in this
-documentation run with SimPy version 1.5 and later.
+SimPy itself can be obtained from:
+https://github.com/SimPyClassic/SimPyClassic.  It is compatible with
+Python version 2.7 onwards.  The examples in this documentation run
+with SimPy version 1.5 and later.
 
 This tutorial should be read with the SimPy Manual and CheatsheetOO at
 your side for reference.
@@ -557,7 +558,7 @@ program the graph is plotted; the user has to terminate the plotting
 
 .. Some of the following links need changing
 
-.. _`SimPy`: http://simpy.sourceforge.net/
+.. _`SimPy`: https://github.com/SimPyClassic/SimPyClassic
 .. _Python: http://www.Python.org
 .. _`Python web site`: http://www.Python.org
 
@@ -578,7 +579,7 @@ References
 
 - Python website: http://www.Python.org
 
-- SimPy homepage: http://simpy.sourceforge.net/
+- SimPy homepage: https://github.com/SimPyClassic/SimPyClassic
 
 - The Bank:
 

--- a/docs/source/Tutorials/TheBankOO.rst
+++ b/docs/source/Tutorials/TheBankOO.rst
@@ -37,7 +37,7 @@ simulation model better than the procedural approach.
 .. _`SimPy`: http://simpy.sourceforge.net/
 
 
-SimPy can be obtained from: http://sourceforge.net/projects/simpy.
+SimPy can be obtained from: https://github.com/SimPyClassic/SimPyClassic.
 This tutorial is best read with the SimPy Manual and CheatsheetOO at
 your side for reference.
 
@@ -938,7 +938,7 @@ References
 
 - Python website: http://www.Python.org
 
-- SimPy website: http://sourceforge.net/projects/simpy
+- SimPy website: https://github.com/SimPyClassic/SimPyClassic
 
 
 ..

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,7 +13,7 @@ standard Python *random* module.
 
 It is based on ideas from Simula and Simscript and provides efficient
 implementation of co-routines using Python's generators capability. It
-requires Python 2.6 or later including Python 3.x. It was first
+requires Python 2.7 or later including Python 3.x. It was first
 released in 2002 under the GNU LGPL.
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = py27,py34,py35,py36,pypy
 
 [testenv]
 deps =
-    mock
     pytest
 
 commands = py.test


### PR DESCRIPTION
removing moc from tox

changing 2.6 to 2.7

references to downloading now point to github.

Still need to change website and doc links - done later. - pre release though.