### PR TITLE
Updated SimStepping manual to be flake8 python 3

### DIFF
--- a/docs/source/Manuals/SimStepManual.rst
+++ b/docs/source/Manuals/SimStepManual.rst
@@ -37,33 +37,10 @@ through a simulation model event by event. It caters for:
 SimulationStep overview
 =======================
 
-Here is a simple program which shows basic event stepping capabilities::
+Here is a simple program which shows basic event stepping capabilities:
 
-    ## Stepping1.py
-    from __future__ import generators
-    from SimPy.SimulationStep import *                  # (1)
-
-    def callbackTimeTrace():                            # (2)
-        """Prints event times
-        """
-        print "at time=%s"%now()
-            
-    class Man(Process):
-        def walk(self):
-            print "got up"
-            yield hold,self,1
-            print "got to door"
-            yield hold,self,10
-            print "got to mail box"
-            yield hold,self,10
-            print "got home again"
-            
-    #trace event times
-    initialize()
-    otto=Man()
-    activate(otto,otto.walk())
-    startStepping()                                     # (3)
-    simulate(callback=callbackTimeTrace,until=100)      # (4)
+.. include:: programs/simstep_stepping1.py
+   :literal:
 
 A trivial simulation model, but with event stepping:
 
@@ -71,54 +48,19 @@ A trivial simulation model, but with event stepping:
  	(2) define a procedure which gets called after every event
  	(3) switch into event stepping mode
 	(4) run the model with event callback to the procedure defined at (2); ``simulate`` in SimulationStep has an extra named parameter, ``callback``.
-    
-Running it produces this output::
 
-    got up
-    at time=0
-    got to door
-    at time=1
-    got to mail box
-    at time=11
-    got home again
-    at time=21
-    at time=21
+Running it produces this output:
+
+.. include:: programs/simstep_stepping1.out
+   :literal:
 
 The callback outputs the simulation time after every event.
 
-Here is another example, the same model, but now with the user getting control back after every 
-event::
+Here is another example, the same model, but now with the user getting control back after every
+event:
 
-    ## Stepping2.py
-    from __future__ import generators
-    from SimPy.SimulationStep import *
-
-    def callbackUserControl():
-        """Allows user to control stepping
-        """
-        a=raw_input("[Time=%s] Select one: End run (e), Continue stepping (s), Run to end (r)= "%now())
-        if a=="e":
-            stopSimulation()
-        elif a=="s":
-            return
-        else:
-            stopStepping()
-            
-    class Man(Process):
-        def walk(self):
-            print "got up"
-            yield hold,self,1
-            print "got to door"
-            yield hold,self,10
-            print "got to mail box"
-            yield hold,self,10
-            print "got home again"
-    #allow user control
-    initialize()
-    otto=Man()
-    activate(otto,otto.walk())
-    startStepping()
-    simulate(callback=callbackUserControl,until=100)
+.. include:: programs/simstep_stepping2.py
+   :literal:
 
 Its interactive output looks like this::
 
@@ -131,7 +73,7 @@ Its interactive output looks like this::
     got home again
     [Time=21] Select one: End run (e), Continue stepping (s), Run to end (r)= s
     [Time=21] Select one: End run (e), Continue stepping (s), Run to end (r)= s
-    
+
 or this (the user stopped stepping mode at time=1)::
 
     got up
@@ -142,51 +84,16 @@ or this (the user stopped stepping mode at time=1)::
     got home again
 
 If one wants to run a tested/debugged model full speed, i.e. without stepping,
-one can write a program as follows::
+one can write a program as follows:
 
-    ## Stepping2Fast.py
-    from __future__ import generators
-    if __debug__:
-	    from SimPy.SimulationStep import *
-    else:
-	    from SimPy.Simulation import *
+.. include:: programs/simstep_stepping2fast.py
+   :literal:
 
-    def callbackUserControl():
-        """Allows user to control stepping
-        """
-        if __debug__:
-		    a=raw_input("[Time=%s] Select one: End run (e), Continue stepping (s),\
-                         Run to end (r)= "%now())
-		    if a=="e":
-		        stopSimulation()
-		    elif a=="s":
-		        return
-		    else:
-		        stopStepping()
-            
-    class Man(Process):
-        def walk(self):
-            print "got up"
-            yield hold,self,1
-            print "got to door"
-            yield hold,self,10
-            print "got to mail box"
-            yield hold,self,10
-            print "got home again"
-    #allow user control if debugging
-    initialize()
-    otto=Man()
-    activate(otto,otto.walk())
-    if __debug__:
-	    startStepping()
-	    simulate(callback=callbackUserControl,until=100)
-    else:
-	    simulate(until=100)
-	    
-If one runs this with the Python command line option '-O', any 
+
+If one runs this with the Python command line option '-O', any
 statement starting with ``if __debug__:`` is ignored/skipped by the
 Python interpreter.
-    
+
 The SimulationStep API
 ======================
 

--- a/docs/source/Manuals/programs/_skip_program_check
+++ b/docs/source/Manuals/programs/_skip_program_check
@@ -1,0 +1,3 @@
+# This program requires input from the user.
+simstep_stepping2.py
+simstep_stepping2fast.py

--- a/docs/source/Manuals/programs/simstep_stepping1.out
+++ b/docs/source/Manuals/programs/simstep_stepping1.out
@@ -1,0 +1,8 @@
+got up
+at time=0
+got to door
+at time=1
+got to mail box
+at time=11
+got home again
+at time=21

--- a/docs/source/Manuals/programs/simstep_stepping1.py
+++ b/docs/source/Manuals/programs/simstep_stepping1.py
@@ -1,0 +1,27 @@
+# simstep_stepping1.py
+import SimPy.SimulationStep as SimulationStep       # (1)
+
+
+def callbackTimeTrace():                            # (2)
+    """Prints event times
+    """
+    print("at time=%s" % SimulationStep.now())
+
+
+class Man(SimulationStep.Process):
+    def walk(self):
+        print("got up")
+        yield SimulationStep.hold, self, 1
+        print("got to door")
+        yield SimulationStep.hold, self, 10
+        print("got to mail box")
+        yield SimulationStep.hold, self, 10
+        print("got home again")
+
+
+# trace event times
+SimulationStep.initialize()
+otto = Man()
+SimulationStep.activate(otto, otto.walk())
+SimulationStep.startStepping()                      # (3)
+SimulationStep.simulate(callback=callbackTimeTrace, until=100)  # (4)

--- a/docs/source/Manuals/programs/simstep_stepping2.py
+++ b/docs/source/Manuals/programs/simstep_stepping2.py
@@ -1,0 +1,35 @@
+# simstep_stepping2.py
+import SimPy.SimulationStep as SimulationStep
+
+
+def callbackUserControl():
+    """Allows user to control stepping
+    """
+    # In python 2.7 you need to make this raw_input
+    a = input("[Time=%s] Select one: End run (e), Continue stepping (s), "
+              "Run to end (r)= " % SimulationStep.now())
+    if a == "e":
+        SimulationStep.stopSimulation()
+    elif a == "s":
+        return
+    else:
+        SimulationStep.stopStepping()
+
+
+class Man(SimulationStep.Process):
+    def walk(self):
+        print("got up")
+        yield SimulationStep.hold, self, 1
+        print("got to door")
+        yield SimulationStep.hold, self, 10
+        print("got to mail box")
+        yield SimulationStep.hold, self, 10
+        print("got home again")
+
+
+# allow user control
+SimulationStep.initialize()
+otto = Man()
+SimulationStep.activate(otto, otto.walk())
+SimulationStep.startStepping()
+SimulationStep.simulate(callback=callbackUserControl, until=100)

--- a/docs/source/Manuals/programs/simstep_stepping2fast.py
+++ b/docs/source/Manuals/programs/simstep_stepping2fast.py
@@ -1,0 +1,43 @@
+# simstep_stepping2fast.py
+
+if __debug__:
+    import SimPy.SimulationStep as Simulation
+else:
+    import SimPy.Simulation as Simulation
+
+
+def callbackUserControl():
+    """Allows user to control stepping
+    """
+    if __debug__:
+        # In python 2.7 you need to make this raw_input
+        a = input("[Time=%s] Select one: End run (e), Continue stepping (s),"
+                  "Run to end (r)= " % Simulation.now())
+        if a == "e":
+            Simulation.stopSimulation()
+        elif a == "s":
+            return
+        else:
+            Simulation.stopStepping()
+
+
+class Man(Simulation.Process):
+    def walk(self):
+        print("got up")
+        yield Simulation.hold, self, 1
+        print("got to door")
+        yield Simulation.hold, self, 10
+        print("got to mail box")
+        yield Simulation.hold, self, 10
+        print("got home again")
+
+
+# allow user control if debugging
+Simulation.initialize()
+otto = Man()
+Simulation.activate(otto, otto.walk())
+if __debug__:
+    Simulation.startStepping()
+    Simulation.simulate(callback=callbackUserControl, until=100)
+else:
+    Simulation.simulate(until=100)


### PR DESCRIPTION
    - Changed raw_input to input which means this example will not run
      python 2.7 unless changed back. There is a comment in the code.
      Where it is used in an example I don't want the complexity of a try
      except around a raw_input.
   - Added _skip_program_check - need to skip programs that ask for input
     from automated testing. They will be flake8 tested though
   - moved programs to outside of the manual.